### PR TITLE
Update cisco-config-parse.rb

### DIFF
--- a/lib/cisco-config-parse.rb
+++ b/lib/cisco-config-parse.rb
@@ -45,7 +45,9 @@ class CiscoConfigParse
     def parse_config(line)
         cmd, opts = line.strip.split(' ', 2)
         meth, opts = meth_and_opts(cmd, opts)
-        send(meth, opts) if respond_to?(meth)
+		if !opts.nil?
+			send(meth, opts) if respond_to?(meth)
+		end
     end
     def meth_and_opts(cmd, opts)
         return negated_meth_and_opts(opts) if cmd =~ /no/


### PR DESCRIPTION
error occurred when the config command like "switchport"

C:/Ruby193/lib/ruby/gems/1.9.1/gems/cisco-config-parse-0.0.5/lib/cisco-config-pa
rse.rb:94:in `p_config_interface_switchport': undefined method`split' for nil:N
ilClass (NoMethodError)
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/cisco-config-parse-0.0.5/lib/ci
sco-config-parse.rb:49:in `parse_config'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/cisco-config-parse-0.0.5/lib/ci
sco-config-parse.rb:16:in`block in parse'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/cisco-config-parse-0.0.5/lib/ci
sco-config-parse.rb:9:in `each'
        from C:/Ruby193/lib/ruby/gems/1.9.1/gems/cisco-config-parse-0.0.5/lib/ci
sco-config-parse.rb:9:in`parse'
        from parse_conf.rb:4:in `<main>'
